### PR TITLE
ramsey/uuid 版本依赖问题

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "workerman/workerman": ">=3.5.0",
         "blogdaren/configurator": "^1.0",
         "blogdaren/logger": "^1.1.2",
-        "ramsey/uuid": "^3.8",
+        "ramsey/uuid": "^3.8 || ^4.0",
         "guzzlehttp/guzzle": "^6.4"
     },
     "suggest": {


### PR DESCRIPTION
```
blogdaren/phpcreeper[v1.3.0, ..., v1.3.1] require ramsey/uuid ^3.8 -> found ramsey/uuid[3.8.0, ..., 3.9.6] but it conflicts with your root composer.json req
uire (^4.2).
```

![image](https://user-images.githubusercontent.com/14959876/162575592-32aeb8e0-692b-4cdf-9f9a-f088399b032e.png)


![image](https://user-images.githubusercontent.com/14959876/162575578-4589c5b4-168b-4d43-b003-e027dc7b25ad.png)
