### PR TITLE
Fix: call to undefined function pprint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,9 @@
     "autoload": {
         "psr-4": {
             "PHPCreeper\\" : "src/"
-        }   
+        },
+        "files": [
+            "src/Kernel/Library/Common/Functions.php"
+        ]
     } 
 }


### PR DESCRIPTION
PHP Fatal error:  Uncaught Error: Call to undefined function pprint() in /home/cheng/PHPCreeper/Application/Sbin/Creeper:191